### PR TITLE
Added if-let pretty-printing

### DIFF
--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -1564,6 +1564,26 @@ impl SolverCtx {
         );
         println!("{}", self.smt.display(lhs));
 
+        // if-let statement processing
+        print!("(if-let "); 
+        for ifLetStruct in &rule.iflets {
+            let if_lhs = &ifLetStruct.lhs;
+            let if_rhs: &cranelift_isle::sema::Expr  = &ifLetStruct.rhs;
+
+            let if_lhs_expr = self.display_isle_pattern(
+                termenv,
+                typeenv,
+                &vars,
+                rule,
+                &if_lhs, 
+            );
+    
+            let if_rhs_expr = self.display_isle_expr(termenv, typeenv, &vars, rule, &if_rhs); 
+
+            print!("({} {})\n", self.smt.display(if_lhs_expr), self.smt.display(if_rhs_expr)); 
+        }
+        print!(")\n");
+
         println!("=>");
         let rhs = self.display_isle_expr(termenv, typeenv, &vars, rule, &rule.rhs);
         println!("{}", self.smt.display(rhs));

--- a/cranelift/isle/veri/veri_engine/src/solver.rs
+++ b/cranelift/isle/veri/veri_engine/src/solver.rs
@@ -1566,9 +1566,9 @@ impl SolverCtx {
 
         // if-let statement processing
         print!("(if-let "); 
-        for ifLetStruct in &rule.iflets {
-            let if_lhs = &ifLetStruct.lhs;
-            let if_rhs: &cranelift_isle::sema::Expr  = &ifLetStruct.rhs;
+        for if_let_struct in &rule.iflets {
+            let if_lhs = &if_let_struct.lhs;
+            let if_rhs: &cranelift_isle::sema::Expr  = &if_let_struct.rhs;
 
             let if_lhs_expr = self.display_isle_pattern(
                 termenv,


### PR DESCRIPTION
Fixes #2 : We edited display_model in solver.rs, such that when there is a counterexample, the printed result includes any if-let statements, which weren't there before. 
