### PR TITLE
Update printer.rs to remove todo!() and replace it by all other tests

### DIFF
--- a/cranelift/isle/isle/src/printer.rs
+++ b/cranelift/isle/isle/src/printer.rs
@@ -520,7 +520,43 @@ impl ToSExpr for SpecExpr {
                     SExpr::List(defs), 
                     body.to_sexpr(), 
                 ])}
-            _ => todo!(),
+            SpecExpr::With {decls, body, pos: _ } => {
+                let decls = decls.iter().map(ToSExpr::to_sexpr).collect::<Vec<_>>();
+                SExpr::List(vec![
+                    SExpr::atom("with"),
+                    SExpr::List(decls),
+                    body.to_sexpr(),
+                ])
+            }
+            SpecExpr::Macro {params, body, pos: _ } => {
+                let params = params.iter().map(ToSExpr::to_sexpr).collect::<Vec<_>>();
+                SExpr::List(vec![
+                    SExpr::atom("macro"),
+                    SExpr::List(params),
+                    body.to_sexpr(),
+                ])
+            }
+            SpecExpr::Expand {name, args, pos: _ } => {
+                let mut parts = vec![SExpr::atom(format!("{}!", name.0))];
+                parts.extend(args.iter().map(ToSExpr::to_sexpr));
+                SExpr::List(parts)
+            }
+            SpecExpr::Pair {l, r, pos: _ } => {
+                SExpr::List(vec![
+                    l.to_sexpr(),
+                    r.to_sexpr(),
+                ])
+            }
+            SpecExpr::Enum {name, variant, args, pos: _ } => {
+                let mut parts = vec![SExpr::atom(format!("{}.{}", name.0, variant.0))];
+                parts.extend(args.iter().map(ToSExpr::to_sexpr));
+                SExpr::List(parts)
+            }
+            SpecExpr::Struct {fields, pos: _ } => {
+                let mut parts = vec![SExpr::atom("struct")];
+                parts.extend(fields.iter().map(ToSExpr::to_sexpr));
+                SExpr::List(parts)
+            }
         }
     }
 }
@@ -777,6 +813,15 @@ impl ToSExpr for ModelField {
         SExpr::List(vec![
             self.name.to_sexpr(),
             self.ty.to_sexpr(),
+        ])
+    }
+}
+
+impl ToSExpr for FieldInit {
+    fn to_sexpr(&self) -> SExpr {
+        SExpr::List(vec![
+            self.name.to_sexpr(),
+            self.value.to_sexpr(),
         ])
     }
 }


### PR DESCRIPTION
This PR replaces the remaining todo!() in impl ToSExpr for SpecExpr with full implementations for all previously unhandled variants.

Specifically, it adds support for:

`With`
`Macro`
`Expand`
`Pair`
`Enum`
`Struct`

Each case is implemented to mirror the syntax expected by the parser, ensuring correct round-trip behavior (AST → printed ISLE → parsed AST).

This prevents runtime panics from unimplemented cases and allows printer-based tests to execute successfully.